### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/alDuncanson/Ginseng/security/code-scanning/6](https://github.com/alDuncanson/Ginseng/security/code-scanning/6)

To fix the problem, add a `permissions:` block at the root level of the workflow YAML file, specifying the minimum needed privilege. For the current workflow, setting `contents: read` is appropriate, ensuring that all jobs only have read access to the repository contents and cannot perform write operations. This change should be made near the top of the file, directly after the workflow `name:` or before/after the `on:` block (the placement order is not strict, but best practice is after the `name:` and before the triggers). No changes are needed within individual jobs, as they inherit from the root unless overridden. No additional methods, imports, or definitions are required; just the insertion of the permissions block.


---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
