### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: Release
+permissions:
+  contents: read
 
 on:
   push:
@@ -13,6 +15,8 @@ concurrency:
 
 jobs:
   create-release:
+    permissions:
+      contents: write
     name: Create GitHub Release
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
Potential fix for [https://github.com/alDuncanson/Ginseng/security/code-scanning/2](https://github.com/alDuncanson/Ginseng/security/code-scanning/2)

The best fix is to add an explicit `permissions` block to the workflow. According to GitHub's least privilege guidance and the fact that the `create-release` job creates GitHub releases, it should be granted only the required permission(s). For most release actions, this is `contents: write`—allowing read/write access to repository contents (creating releases and uploading assets). If other jobs in the workflow don't require extra permissions, it's safest to set the global workflow-level permissions to `contents: read` (the strictest appropriate for the whole workflow), and then override the necessary jobs with more permissive settings (e.g., `contents: write` for `create-release`). Since only the `create-release` job is flagged and needs `write`, and the rest likely only need read to fetch code, follow this pattern:

- Add a top-level `permissions: contents: read` block soon after the workflow `name`.
- Add a `permissions: contents: write` block inside the `create-release:` job.

This ensures least privilege is in force by default, and escalates only where necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
